### PR TITLE
Fixed spelling mistake in supervisord config file

### DIFF
--- a/7.1/supervisord.conf
+++ b/7.1/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
-[program:php5-fpm]
+[program:php7-fpm]
 command = /usr/sbin/php-fpm7.1 -F
 autostart = true
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Fixed the spelling mistake inside the supervisord configuration file. Doesn't matter for the execution of the program. I think it's just a copy/paste mistake.